### PR TITLE
Embed Perplexity mini via iframe

### DIFF
--- a/index.html
+++ b/index.html
@@ -254,7 +254,7 @@
                         <div class="uploaded-image" id="preview-container" style="display: none;">
                             <h3>Image Preview</h3>
                             <div class="image-container">
-                                <img id="uploaded-img" src="" alt="Uploaded image">
+                                <img id="uploaded-img" src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="Uploaded image">
                             </div>
                         </div>
                     </div>
@@ -396,6 +396,18 @@
             </div>
         </aside>
     </div>
+
+    <!-- Perplexity Mini -->
+    <section class="perplexity-mini">
+        <h2>Perplexity AI Mini</h2>
+        <iframe
+            src="https://www.perplexity.ai/apps/0f65ed57-9147-440e-90bb-16606bc77c6c"
+            width="100%"
+            height="600"
+            style="border:0;"
+            allowfullscreen>
+        </iframe>
+    </section>
 
     <!-- Enhanced Modals -->
     <div class="modal hidden" id="save-modal">

--- a/style.css
+++ b/style.css
@@ -1209,3 +1209,14 @@ body {
   margin-bottom: var(--space-sm);
   cursor: pointer;
 }
+
+/* Perplexity mini embed */
+.perplexity-mini {
+  margin: var(--space-lg) 0;
+}
+
+.perplexity-mini iframe {
+  width: 100%;
+  height: 600px;
+  border: 0;
+}


### PR DESCRIPTION
## Summary
- embed Perplexity AI mini in `index.html`
- style the mini iframe for full-width display
- add placeholder image source to satisfy HTML linting

## Testing
- `npx --yes htmlhint index.html`
- `node --check app.js`
- `python -m py_compile script.py script_1.py script_2.py script_3.py`


------
https://chatgpt.com/codex/tasks/task_b_68c5284eae808331a93fc9e0777bf51d