### PR TITLE
Integrate Chota Dhamakaa mini generator

### DIFF
--- a/app.js
+++ b/app.js
@@ -398,6 +398,14 @@ function setupEventListeners() {
         batchBtn.addEventListener('click', generateBatch);
     }
 
+    const miniLink = document.getElementById('mini-generator-link');
+    if (miniLink) {
+        miniLink.addEventListener('click', function(e) {
+            e.preventDefault();
+            switchTab('mini-generator');
+        });
+    }
+
     console.log('✅ Event listeners configured');
 }
 

--- a/classicpg/app.js
+++ b/classicpg/app.js
@@ -1,7 +1,34 @@
-// Latina AI Art Prompt Generator - JavaScript
+// Chota Dhamakaa Prompt Generator - JavaScript
+
+let currentTheme = 'cyberpunk_neon';
+const themes = {
+    dark_professional: { primary: '#3b82f6', background: '#0f172a' },
+    light_modern: { primary: '#0ea5e9', background: '#ffffff' },
+    cyberpunk_neon: { primary: '#00ff88', background: '#000000' },
+    warm_autumn: { primary: '#d97706', background: '#1c1917' },
+    ocean_blue: { primary: '#0284c7', background: '#082f49' },
+    pastel_dreams: { primary: '#a855f7', background: '#fefce8' },
+    forest_green: { primary: '#059669', background: '#022c22' },
+    sunset_gradient: { primary: '#f59e0b', background: '#431407' }
+};
+
+function applyTheme(themeName) {
+    currentTheme = themeName;
+    document.body.setAttribute('data-theme', themeName);
+    if (themes[themeName]) {
+        document.documentElement.style.setProperty('--theme-primary', themes[themeName].primary);
+        document.documentElement.style.setProperty('--theme-background', themes[themeName].background);
+    }
+}
 
 document.addEventListener('DOMContentLoaded', function() {
     console.log('DOM loaded, initializing app...');
+
+    const themeSelect = document.getElementById('theme-select');
+    if (themeSelect) {
+        themeSelect.addEventListener('change', e => applyTheme(e.target.value));
+        applyTheme(themeSelect.value);
+    }
     
     // Data templates and settings
     const promptData = {

--- a/classicpg/index.html
+++ b/classicpg/index.html
@@ -3,14 +3,32 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Latina AI Art Prompt Generator</title>
+    <title>Chota Dhamakaa Prompt Generator</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="../style.css">
 </head>
-<body>
+<body data-theme="cyberpunk_neon">
     <div class="container">
         <header class="header">
-            <h1>Latina AI Art Prompt Generator</h1>
+            <h1>Chota Dhamakaa Prompt Generator</h1>
             <p class="subtitle">Professional prompt generator specialized in creating stunning Latina woman portraits</p>
+            <div class="theme-selector">
+                <label for="theme-select"><i class="fas fa-palette"></i> Theme:</label>
+                <select id="theme-select" class="form-control">
+                    <option value="cyberpunk_neon" selected>Cyberpunk Neon</option>
+                    <option value="dark_professional">Dark Professional</option>
+                    <option value="light_modern">Light Modern</option>
+                    <option value="warm_autumn">Warm Autumn</option>
+                    <option value="ocean_blue">Ocean Blue</option>
+                    <option value="pastel_dreams">Pastel Dreams</option>
+                    <option value="forest_green">Forest Green</option>
+                    <option value="sunset_gradient">Sunset Gradient</option>
+                </select>
+            </div>
         </header>
 
         <main class="main-content">

--- a/index.html
+++ b/index.html
@@ -54,8 +54,8 @@
             <button class="btn btn--primary" id="export-btn">
                 <i class="fas fa-download"></i> Export
             </button>
-            <a class="btn btn--outline" id="mini-generator-link" href="classicpg/index.html">
-                <i class="fas fa-bolt"></i> Mini Generator
+            <a class="btn btn--outline" id="mini-generator-link" href="#">
+                <i class="fas fa-bolt"></i> Chota Dhamakaa
             </a>
         </div>
     </header>
@@ -155,6 +155,9 @@
                 </button>
                 <button class="tab" data-tab="batch-generator">
                     <i class="fas fa-clone"></i> Batch Generator
+                </button>
+                <button class="tab" data-tab="mini-generator">
+                    <i class="fas fa-bolt"></i> Chota Dhamakaa
                 </button>
             </nav>
 
@@ -326,6 +329,10 @@
                         <!-- Generated variations will appear here -->
                     </div>
                 </div>
+            </div>
+            <!-- Chota Dhamakaa Mini Generator Tab -->
+            <div class="tab-content" id="mini-generator-tab">
+                <iframe src="classicpg/index.html" class="mini-frame"></iframe>
             </div>
         </main>
 

--- a/style.css
+++ b/style.css
@@ -1209,3 +1209,10 @@ body {
   margin-bottom: var(--space-sm);
   cursor: pointer;
 }
+
+/* Chota Dhamakaa mini generator */
+.mini-frame {
+  width: 100%;
+  height: 80vh;
+  border: none;
+}


### PR DESCRIPTION
## Summary
- Add "Chota Dhamakaa" tab and header button to access the mini prompt generator within the app
- Enable theming and shared styles for the mini generator page
- Style iframe container for embedded mini generator

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68c53c444e80833186bc62be03463f8b