### PR TITLE
Add prompt length control and remove templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@ This package contains everything you need to deploy a fully functional AI Prompt
 - **5 AI Platforms**: Midjourney, Stable Diffusion, Flux AI, DALL-E, Natural Language
 - **8 Themes**: Dark Professional, Light Modern, Cyberpunk Neon, Warm Autumn, Ocean Blue, Pastel Dreams, Forest Green, Sunset Gradient
 - **3000+ Word Library**: Organized in 6 categories with smart search
-- **500+ Templates**: Professional prompt templates across 10 categories
 - **Random Generators**: 6 intelligent prompt generators
 - **Advanced Rules**: Quality scoring and optimization
+- **Prompt Length Control**: Adjust prompt verbosity with a slider
 
 ### 🚀 Additional Modern Features:
 - **AI Suggestions**: Smart recommendations for prompt improvement
 - **Batch Generation**: Create multiple prompt variations
  - **Image-to-Prompt**: Upload and analyze images with natural language toggle
 - **Local Transformers AI**: Free text generation and image captioning without API keys
-- **Auto-Optimize**: One-click expansion to 700+ character prompts
+- **Auto-Optimize**: One-click expansion respecting your chosen length
 - **Real-time Quality Scoring**: 0-100% prompt assessment
 - **History & Saving**: Persistent prompt history and favorites
 - **Export Options**: Copy, save, and share functionality
@@ -67,7 +67,6 @@ npx http-server
    - Type manually in the textarea
    - Click words from the smart library
    - Use random generators for inspiration  
-   - Apply professional templates
    - Upload images for analysis
 
 ### Pro Tips:
@@ -95,19 +94,7 @@ npx http-server
 - **Composition**: Camera angles, framing, depth techniques
 - **Moods**: Positive, negative, and neutral emotions
 
-### 3. **Professional Templates (500+)**
-- **Portrait Photography** (75 templates)
-- **Landscape Art** (60 templates)
-- **Digital Art** (85 templates)
-- **Fantasy Scenes** (70 templates)
-- **Abstract Art** (45 templates)
-- **Character Design** (65 templates)
-- **Architecture** (40 templates)
-- **Product Photography** (35 templates)
-- **Fashion Design** (30 templates)
-- **Concept Art** (45 templates)
-
-### 4. **AI-Powered Quality Scoring**
+### 3. **AI-Powered Quality Scoring**
 Evaluates prompts based on:
 - **Length**: Optimal word count for each platform
 - **Descriptiveness**: Rich adjectives and details
@@ -130,11 +117,6 @@ Evaluates prompts based on:
 1. Open `app.js`
 2. Find the `wordLibrary` object
 3. Add words to existing categories or create new ones
-
-### Adding New Templates:
-1. Open `app.js`  
-2. Find the `promptTemplates` object
-3. Add new template objects with name, template, and category
 
 ### Creating New Themes:
 1. Open `style.css`
@@ -222,7 +204,7 @@ This foundation supports easy addition of:
 
 ### Example 2: Digital Art
 1. Select words: "cyberpunk" + "neon" + "cityscape" + "dramatic"
-2. Apply "Sci-Fi Concept" template
+2. Combine elements for a cyberpunk cityscape, neon lighting, dramatic atmosphere
 3. Result: "Cyberpunk cityscape, neon lighting, dramatic atmosphere, digital art style, highly detailed"
 
 ### Example 3: Fantasy Scene

--- a/index.html
+++ b/index.html
@@ -147,9 +147,6 @@
                 <button class="tab active" data-tab="manual">
                     <i class="fas fa-edit"></i> Manual Builder
                 </button>
-                <button class="tab" data-tab="templates">
-                    <i class="fas fa-layer-group"></i> Templates (500+)
-                </button>
                 <button class="tab" data-tab="image-to-prompt">
                     <i class="fas fa-image"></i> Image to Prompt
                 </button>
@@ -179,11 +176,17 @@
                         </div>
                     </div>
 
+                    <div class="prompt-settings">
+                        <label for="prompt-length">Prompt Length</label>
+                        <input type="range" id="prompt-length" min="100" max="700" step="100" value="300">
+                        <span id="prompt-length-display">Medium</span>
+                    </div>
+
                     <div class="prompt-editor">
-                        <textarea 
-                            id="prompt-textarea" 
-                            class="prompt-textarea" 
-                            placeholder="Describe your vision... (or use voice input, drag words, or apply templates)"
+                        <textarea
+                            id="prompt-textarea"
+                            class="prompt-textarea"
+                            placeholder="Describe your vision... (or use voice input or drag words)"
                             rows="8"
                         ></textarea>
 
@@ -203,42 +206,7 @@
                 </div>
             </div>
 
-            <!-- Enhanced Templates Tab -->
-            <div class="tab-content" id="templates-tab">
-                <div class="template-section">
-                    <div class="template-header">
-                        <h2>Professional Templates</h2>
-                        <div class="template-filters">
-                            <select id="complexity-filter" class="form-control">
-                                <option value="all">All Complexity</option>
-                                <option value="beginner">Beginner</option>
-                                <option value="intermediate">Intermediate</option>
-                                <option value="advanced">Advanced</option>
-                                <option value="expert">Expert</option>
-                            </select>
-                        </div>
-                    </div>
-
-                    <div class="template-categories">
-                        <button class="template-category-btn active" data-category="all">All Templates</button>
-                        <button class="template-category-btn" data-category="portrait">Portrait (75)</button>
-                        <button class="template-category-btn" data-category="landscape">Landscape (60)</button>
-                        <button class="template-category-btn" data-category="digital_art">Digital Art (85)</button>
-                        <button class="template-category-btn" data-category="photography">Photography (65)</button>
-                        <button class="template-category-btn" data-category="fantasy">Fantasy (70)</button>
-                        <button class="template-category-btn" data-category="abstract">Abstract (45)</button>
-                        <button class="template-category-btn" data-category="character">Character (65)</button>
-                        <button class="template-category-btn" data-category="architecture">Architecture (40)</button>
-                        <button class="template-category-btn" data-category="concept_art">Concept Art (45)</button>
-                    </div>
-
-                    <div class="template-grid" id="template-grid">
-                        <!-- Templates populated by JavaScript -->
-                    </div>
-                </div>
-            </div>
-
-            <!-- Enhanced Image to Prompt Tab -->
+              <!-- Enhanced Image to Prompt Tab -->
             <div class="tab-content" id="image-to-prompt-tab">
                 <div class="image-upload-area">
                     <div class="upload-section">
@@ -256,6 +224,8 @@
                                 </button>
                             </div>
                         </div>
+
+                        <div class="upload-status" id="upload-status" aria-live="polite"></div>
 
                         <div class="uploaded-image" id="preview-container" style="display: none;">
                             <h3>Image Preview</h3>

--- a/style.css
+++ b/style.css
@@ -510,6 +510,18 @@ body {
   gap: var(--space-sm);
 }
 
+.prompt-settings {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  margin: var(--space-md) 0;
+  font-size: 0.875rem;
+}
+
+.prompt-settings input[type="range"] {
+  flex: 1;
+}
+
 .prompt-editor {
   position: relative;
 }
@@ -656,106 +668,6 @@ body {
   margin-bottom: var(--space-sm);
   font-weight: 500;
   color: var(--theme-text);
-}
-
-/* Template System */
-.template-section {
-  display: grid;
-  gap: var(--space-xl);
-}
-
-.template-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.template-categories {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-sm);
-}
-
-.template-category-btn {
-  padding: var(--space-sm) var(--space-lg);
-  background: var(--theme-surface);
-  border: 1px solid var(--theme-border);
-  border-radius: var(--radius-full);
-  color: var(--theme-text);
-  font-size: 0.875rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all var(--transition-fast);
-}
-
-.template-category-btn.active,
-.template-category-btn:hover {
-  background: var(--theme-primary);
-  color: var(--theme-background);
-  border-color: var(--theme-primary);
-}
-
-.template-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
-  gap: var(--space-lg);
-}
-
-.template-card {
-  background: var(--theme-surface);
-  border: 1px solid var(--theme-border);
-  border-radius: var(--radius-lg);
-  padding: var(--space-lg);
-  cursor: pointer;
-  transition: all var(--transition-fast);
-  position: relative;
-  overflow: hidden;
-}
-
-.template-card::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 3px;
-  background: var(--theme-primary);
-  transform: scaleX(0);
-  transition: transform var(--transition-fast);
-}
-
-.template-card:hover {
-  border-color: var(--theme-primary);
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-lg);
-}
-
-.template-card:hover::before {
-  transform: scaleX(1);
-}
-
-.template-card h4 {
-  font-size: 1.125rem;
-  font-weight: 600;
-  color: var(--theme-primary);
-  margin-bottom: var(--space-sm);
-}
-
-.template-card p {
-  color: var(--theme-text-secondary);
-  font-size: 0.875rem;
-  margin-bottom: var(--space-md);
-}
-
-.template-preview {
-  background: var(--theme-background);
-  border: 1px solid var(--theme-border);
-  border-radius: var(--radius-sm);
-  padding: var(--space-sm);
-  font-family: var(--font-mono);
-  font-size: 0.75rem;
-  color: var(--theme-text-secondary);
-  line-height: 1.4;
 }
 
 /* Right Panel */
@@ -925,6 +837,12 @@ body {
 .upload-icon {
   font-size: 48px;
   color: var(--theme-primary);
+}
+
+.upload-status {
+  margin-top: var(--space-md);
+  font-size: 0.875rem;
+  color: var(--theme-text-secondary);
 }
 
 /* Image preview and analysis results */
@@ -1097,9 +1015,6 @@ body {
   box-shadow: 0 0 20px var(--theme-primary);
 }
 
-[data-theme="cyberpunk_neon"] .template-card:hover {
-  box-shadow: 0 0 30px rgba(0, 255, 136, 0.3);
-}
 
 /* Responsive Design */
 @media (max-width: 1200px) {
@@ -1146,9 +1061,6 @@ body {
     flex-wrap: wrap;
   }
 
-  .template-grid {
-    grid-template-columns: 1fr;
-  }
 }
 
 /* Accessibility */


### PR DESCRIPTION
## Summary
- add slider to adjust prompt length and stop auto-expansion
- drop templates section and associated styles
- sync theme dropdown with applied theme and tighten image-to-prompt API handling

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `node <<'NODE' ... NODE` (theme option consistency)


------
https://chatgpt.com/codex/tasks/task_b_68c54676369c83318b407648218a287b