### PR TITLE
feat: add basic mobile layout with responsive header

### DIFF
--- a/app.js
+++ b/app.js
@@ -195,6 +195,14 @@ const themes = {
 document.addEventListener('DOMContentLoaded', function() {
     console.log('✅ DOM loaded, initializing app...');
     initializeApp();
+
+    const menuToggle = document.getElementById('menu-toggle');
+    const sidebar = document.querySelector('.sidebar');
+    if (menuToggle && sidebar) {
+        menuToggle.addEventListener('click', () => {
+            sidebar.classList.toggle('show');
+        });
+    }
 });
 
 function initializeApp() {

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
     <!-- Enhanced Header with Modern Features -->
     <header class="header">
         <div class="header-left">
+            <button class="hamburger" id="menu-toggle" aria-label="Toggle navigation">&#9776;</button>
             <div class="logo">
                 <h1><i class="fas fa-magic"></i> AI Prompt Generator v2.0</h1>
                 <span class="version-badge">Advanced</span>
@@ -162,7 +163,7 @@
             <div class="tab-content active" id="manual-tab">
                 <div class="prompt-workspace">
                     <div class="workspace-header">
-                        <h2>Build Your Prompt</h2>
+                        <h2 class="workspace-title">Build Your Prompt</h2>
                         <div class="workspace-tools">
                             <button class="btn btn--sm btn--outline" id="clear-prompt">
                                 <i class="fas fa-trash"></i> Clear

--- a/style.css
+++ b/style.css
@@ -1140,3 +1140,82 @@ body {
   height: 500px;
   border: none;
 }
+
+/* Mobile navigation button */
+.hamburger {
+  display: none;
+  background: none;
+  border: none;
+  color: var(--theme-text);
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+/* Workspace title */
+.workspace-title {
+  font-size: 1.75rem;
+}
+
+/* Mobile First Approach */
+@media screen and (max-width: 480px) {
+  body {
+    padding: 60px 12px 12px 12px;
+  }
+
+  .header {
+    height: 60px;
+    padding: 0 var(--space-md);
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    z-index: 1000;
+  }
+
+  .logo h1 {
+    font-size: 1.5rem;
+  }
+
+  .header-right .btn,
+  .header-center select,
+  .header-center label {
+    min-height: 44px;
+  }
+
+  .app-container {
+    display: flex;
+    flex-direction: column;
+    max-width: 100%;
+  }
+
+  .workspace-title {
+    font-size: 1.5rem;
+  }
+
+  .hamburger {
+    display: block;
+  }
+
+  .sidebar {
+    display: none;
+  }
+
+  .sidebar.show {
+    display: block;
+    position: fixed;
+    top: 60px;
+    left: 0;
+    width: 100%;
+    height: calc(100% - 60px);
+    overflow-y: auto;
+    background: var(--theme-surface);
+    z-index: 999;
+    padding: var(--space-lg);
+  }
+}
+
+@media screen and (orientation: landscape) {
+  .header {
+    height: 50px;
+  }
+}


### PR DESCRIPTION
## Summary
- add hamburger menu and mobile title styling
- introduce mobile-first CSS with fixed header and touch targets
- toggle sidebar visibility via menu button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c54d289ad08331ace948a171e4c32c